### PR TITLE
Fixed bug in example code in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -68,7 +68,7 @@ And finally, you can setup listeners for specific messages, like you would in an
 controller.hears(['hi', 'hello'], 'message_received', (bot, message) => {
   bot.startConversation(message, (err, convo) => {
     convo.say('Hi, I am Oliver, an SMS bot! :D')
-    convo.ask('What is your name?', (err, res) => {
+    convo.ask('What is your name?', (res, convo) => {
       convo.say(`Nice to meet you, ${res.text}!`)
       convo.next()
     })


### PR DESCRIPTION
I'm new to botkit in general and especially botkit-sms, but testing the example code that was included didn't produce the desired output. A little debugging later and it turns out that the arguments to the say() function were incorrect.
