### PR TITLE
Fixed reply function

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -70,7 +70,13 @@ function TwilioSMS (configuration) {
 
       msg.channel = src.channel
 
-      bot.say(msg, cb)
+      // Handle optional callback
+      if (typeof cb === 'function') {
+        bot.say(msg, cb)
+      } else {
+        bot.say(msg, function () {})
+      }
+
     }
 
     bot.findConversation = function (message, cb) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botkit-sms",
-  "version": "1.0.3",
+  "version": "1.0.5",
   "description": "Twilio Programmable SMS implementation for Botkit.",
   "main": "lib/index.js",
   "author": "Kristian Muñiz <kristian.muniz@upr.edu> (http://www.krismuniz.com)",


### PR DESCRIPTION
According to the botkit docs, the bot.reply() function takes an optional callback as the last argument. The implementation in botkit-sms originally crashed if a callback was not passed in to the function. This pull request fixes that, and bumps the package version to v1.0.5.
