### PR TITLE
Added startPrivateConversation function and bumped package version

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -38,6 +38,12 @@ function TwilioSMS (configuration) {
       botkit.startConversation(this, message, cb)
     }
 
+    bot.startPrivateConversation = function (message, cb) {
+      // Allow startPrivateConversation to only take the user as a param
+      message.channel = message.user
+      botkit.startConversation(this, message, cb)
+    }
+
     bot.send = function (message, cb) {
       const client = new twilio.RestClient(
         configuration.account_sid,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botkit-sms",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Twilio Programmable SMS implementation for Botkit.",
   "main": "lib/index.js",
   "author": "Kristian Muñiz <kristian.muniz@upr.edu> (http://www.krismuniz.com)",


### PR DESCRIPTION
While startPrivateConversation() is listed as "slack-only for now" in botkit, I decided it could be nice for botkit-sms to be able to use as much already existing code as possible. This one's really developer's choice if you want to include it or not.
