### PR TITLE
Fix Twilio error with invalid mediaUrl

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -51,9 +51,10 @@ function TwilioSMS(configuration) {
       let sms = {
         body: message.text,
         from: configuration.twilio_number,
-        to: message.channel,
-        mediaUrl: message.mediaUrl || undefined
+        to: message.channel
       }
+      
+      if ('mediaUrl' in message) sms.mediaUrl = message.mediaUrl;
 
       client.messages.create(sms, (err, message) => {
         if (err) {


### PR DESCRIPTION
Fixes https://github.com/krismuniz/botkit-sms/issues/14.